### PR TITLE
19 - add guide in console

### DIFF
--- a/srcServer/db.js
+++ b/srcServer/db.js
@@ -12,7 +12,8 @@ mongoose.connect(`mongodb://localhost:27017/${process.env.DBNAME}`, {
     if (!err)
         console.log( chalk.greenBright('\nMongoDB connection successful!!!') );
     else
-        console.log( chalk.redBright(`Error in DB connection: ${err.message} \n`) );
+        console.log( chalk.redBright(`\nError in DB connection: ${err.message} \n`) );
+        console.log( chalk.yellowBright(`Please make sure you: \n1. Have mongoDB installed & running locally (or are connected to mongoDB atlas). \n2. Update nodemon.json file with your DB name (and password in the case of atlas).\n`) );
 });
 
 export const mongooseModuleExport = mongoose;


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#19

**Details:**
* Add guide/instructions in console to help user set up mongoDB connection, as continuation of readme instructions.

**Testing checklist:**
- [x] Guide is added as console message (in yellow) after the `error in db connection` message.

- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli