### PR TITLE
19 - Fix guide for installed mongoDB option

### DIFF
--- a/srcServer/db.js
+++ b/srcServer/db.js
@@ -9,11 +9,23 @@ mongoose.connect(`mongodb://localhost:27017/${process.env.DBNAME}`, {
     useFindAndModify: false
 },
  err => {
-    if (!err)
-        console.log( chalk.greenBright('\nMongoDB connection successful!!!') );
-    else
-        console.log( chalk.redBright(`\nError in DB connection: ${err.message} \n`) );
-        console.log( chalk.yellowBright(`Please make sure you: \n1. Have mongoDB installed & running locally (or are connected to mongoDB atlas). \n2. Update srcServer > nodemon.json file with your DB name (and password in the case of mongoDB atlas).\n`) );
+    if (!err) {
+      console.log( chalk.greenBright('\nInstalled MongoDB connection successful!!!') );
+    }
+    else {
+      console.log( chalk.redBright(`\nError in DB connection: ${err.message} \n`) );
+      console.log( chalk.yellowBright(`To use installed mongoDB option, make sure you:
+      => Have mongoDB installed & running locally
+        - See https://docs.mongodb.com/guides/server/install/
+      => Update srcServer > nodemon.json file with your DB name
+        - ensure you didn't mispell or include wrong details.
+
+    To use or see guide for MongoDB ATLAS option:
+      => Comment out import for === Installed mongoDB's db === in srcServer > app.js,
+        and use import for === MongoDB ATLAS db === instead.
+      `
+    ) );
+    }
 });
 
 export const mongooseModuleExport = mongoose;


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#19

**Details:**
* Fixes guide i.e. adds guide specific to installed mongoDB option usage.

**Testing checklist:**
- [x] Run `npm start` or `npm start -s` command.
- [x] Check that guide for using installed mongoDB option is displayed when there's error in connection. 
- [x] Check that success message is displayed when DB connection is successful.
- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli