### PR TITLE
39 - contributing to the starter-kit section of readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Development environment has been set up already i.e. connection to server & db, 
 Replace `insert-your-project-name` with your own project name in `srcServer > startMessage.js`.
 
 ## Contributing to the starter-kit
-See [contributing to node-mongo-cli section](https://github.com/code-collabo/node-mongo-cli) of ***node-mongo-cli repo's readme*** for how to contribute to the project.
+You can contribute as a `nodejs developer`, `mongoDB developer` and/or help with `documentation` & `research`. We are still working on documentation, but please go through these before you start contributing:
+* For anyone who will be writing, mentoring and/or reviewing code, in any or both of these repos: [node-mongo-cli repo](https://github.com/code-collabo/node-mongo-cli) and [node-mongo-starter-kit repo](https://github.com/code-collabo/node-mongo-starter-kit), the [first task assignment](https://github.com/code-collabo/node-mongo-cli/issues/1#issuecomment-785559734) needs to be completed & submitted first.
+* Also, please do not make changes directly in the `main` or `develop` branches. See [development environment & git workflow](https://github.com/code-collabo/node-mongo-docs/issues/2) on how to make changes to the code base and submit pull request.
+* Please leave a comment under the issue you wish to work on and wait for approval before you send in a pull request. See [contribution & community guidelines](https://github.com/code-collabo/node-mongo-docs/issues/3) for complete details.
 
+Feel free to ask questions concerning anything not clear on this topic if you have any. Just ask your question(s) in the comment under the issue you wish to work on and you'll be attended to. It is better to ask if you're not sure, than for your pull request to be discarded.
 
 ## Related repositories
 This is the repository for the files and folders that the node-mongo-cli will set up for you, made by Code Collabo community. Other related repos to the cli project:


### PR DESCRIPTION
**This pull request makes the following changes:**
* Fixes issue code-collabo/node-mongo-cli#39

**Details:**
* Add detailed info to **contributing to the starter-kit** section of readme to help first time contributors understand how to contribute.

**Testing checklist:**
- [x] Check that all the links added are working.

- [x] I certify that I ran my checklist.

Ping @code-collabo/node-mongo-cli